### PR TITLE
[#169058661] Ändere PID File location auf /run/*.pid

### DIFF
--- a/templates/usr/lib/systemd/system/haproxy.service.j2
+++ b/templates/usr/lib/systemd/system/haproxy.service.j2
@@ -8,7 +8,7 @@ Wants=network-online.target
 [Service]
 EnvironmentFile=-/etc/default/{{ _haproxy.instance_name }}
 EnvironmentFile=-/etc/sysconfig/{{ _haproxy.instance_name }}
-Environment="CONFIG=/etc/{{ _haproxy.instance_name }}/{{ _haproxy.instance_name }}.cfg" "PIDFILE=/run/{{ _haproxy.instance_name }}" "EXTRAOPTS=-S /run/haproxy-master.sock"
+Environment="CONFIG=/etc/{{ _haproxy.instance_name }}/{{ _haproxy.instance_name }}.cfg" "PIDFILE=/run/{{ _haproxy.instance_name }}.pid" "EXTRAOPTS=-S /run/haproxy-master.sock"
 ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q $EXTRAOPTS
 ExecStart=/usr/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE $EXTRAOPTS
 ExecReload=/usr/sbin/haproxy -f $CONFIG -c -q $EXTRAOPTS


### PR DESCRIPTION
- Auf SystemD Systemen, wo der `instance_name: "haproxy"` gesetzt ist wird der HAProxy nicht erfolgreich gestartet, da der Pfad der PID schon als Ordner existiert.
- Durch den PR wird das alte PID Verhalten / Location der 14.04 HAProxy Instanzen wieder genutzt